### PR TITLE
Ensure consistent block naming and interactions across views

### DIFF
--- a/BlockViz.Application/Extensions/BlockExtensions.cs
+++ b/BlockViz.Application/Extensions/BlockExtensions.cs
@@ -5,6 +5,8 @@ namespace BlockViz.Applications.Extensions
 {
     public static class BlockExtensions
     {
+        private const string UnnamedBlockLabel = "(무명 블록)";
+
         public static DateTime? GetEffectiveEnd(this Block block)
         {
             if (block == null)
@@ -44,6 +46,22 @@ namespace BlockViz.Applications.Extensions
 
             var end = block.GetEffectiveEnd();
             return end == null || date <= end.Value;
+        }
+
+        public static string GetDisplayName(this Block block)
+        {
+            if (block == null)
+            {
+                return UnnamedBlockLabel;
+            }
+
+            return GetDisplayName(block.Name);
+        }
+
+        public static string GetDisplayName(string? blockName)
+        {
+            var trimmed = blockName?.Trim();
+            return string.IsNullOrEmpty(trimmed) ? UnnamedBlockLabel : trimmed;
         }
     }
 }

--- a/BlockViz.Application/Models/BlockIntervalBarItem.cs
+++ b/BlockViz.Application/Models/BlockIntervalBarItem.cs
@@ -1,0 +1,22 @@
+using System;
+using BlockViz.Applications.Extensions;
+using BlockViz.Domain.Models;
+using OxyPlot.Series;
+
+namespace BlockViz.Applications.Models
+{
+    /// <summary>
+    /// 간트 막대 항목과 실제 Block 모델을 연결하기 위한 경량 래퍼입니다.
+    /// 기존 SelectionService 전달 경로를 유지하면서 Block 참조를 보존하기 위해 추가했습니다.
+    /// </summary>
+    public sealed class BlockIntervalBarItem : IntervalBarItem
+    {
+        public BlockIntervalBarItem(Block block)
+        {
+            Block = block ?? throw new ArgumentNullException(nameof(block));
+            Title = block.GetDisplayName();
+        }
+
+        public Block Block { get; }
+    }
+}

--- a/BlockViz.Application/ViewModels/FactoryViewModel.cs
+++ b/BlockViz.Application/ViewModels/FactoryViewModel.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.ComponentModel.Composition;
 using System.Windows.Media.Media3D;
+using BlockViz.Applications.Extensions;
 using BlockViz.Applications.Services;
 using BlockViz.Applications.Views;
 using System.Waf.Applications;
@@ -98,7 +99,8 @@ namespace BlockViz.Applications.ViewModels
                     {
                         if (child is BoxVisual3D box)
                         {
-                            var brush = colorService.GetBrush(b.Name);
+                            var displayName = b.GetDisplayName();
+                            var brush = colorService.GetBrush(displayName);
                             var material = MaterialHelper.CreateMaterial(brush);
                             box.Material = material;
                             box.BackMaterial = material;

--- a/BlockViz.Application/ViewModels/PiViewModel.cs
+++ b/BlockViz.Application/ViewModels/PiViewModel.cs
@@ -129,7 +129,8 @@ namespace BlockViz.Applications.ViewModels
                     var s = b.Start < windowStart ? windowStart : b.Start;
                     var e = effectiveEnd > windowEnd ? windowEnd : effectiveEnd;
                     if (e <= s) continue;
-                    clipped.Add((b.Name, s, e));
+                    var displayName = b.GetDisplayName();
+                    clipped.Add((displayName, s, e));
                 }
 
                 if (!clipped.Any())

--- a/BlockViz.Application/ViewModels/ScheduleViewModel.cs
+++ b/BlockViz.Application/ViewModels/ScheduleViewModel.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.ComponentModel.Composition;
 using System.Windows.Media.Media3D;
+using BlockViz.Applications.Extensions;
 using BlockViz.Applications.Services;
 using BlockViz.Applications.Views;
 using System.Waf.Applications;
@@ -98,7 +99,8 @@ namespace BlockViz.Applications.ViewModels
                     {
                         if (child is BoxVisual3D box)
                         {
-                            var brush = colorService.GetBrush(b.Name);
+                            var displayName = b.GetDisplayName();
+                            var brush = colorService.GetBrush(displayName);
                             var material = MaterialHelper.CreateMaterial(brush);
                             box.Material = material;
                             box.BackMaterial = material;

--- a/BlockViz.Application/Views/IGanttView.cs
+++ b/BlockViz.Application/Views/IGanttView.cs
@@ -1,6 +1,7 @@
 // BlockViz.Applications\Views\IGanttView.cs
 using System;
 using System.Waf.Applications;
+using BlockViz.Domain.Models;
 using PlotModel = OxyPlot.PlotModel;
 
 namespace BlockViz.Applications.Views
@@ -11,10 +12,16 @@ namespace BlockViz.Applications.Views
 
         event EventHandler<WorkplaceFilterRequestedEventArgs> WorkplaceFilterRequested;
 
+        event EventHandler<bool> ExpandAllChanged;
+
+        event Action<Block> BlockClicked;
+
         /// <summary>
         /// UI 버튼 상태를 동기화하기 위해 현재 선택된 작업장을 설정합니다.
         /// null이면 기본 보기(모든 작업장)를 의미합니다.
         /// </summary>
         void SetActiveWorkplace(int? workplaceId);
+
+        void SetExpandAllState(bool isExpanded);
     }
 }

--- a/BlockViz.Presentation/Views/FactoryView.xaml.cs
+++ b/BlockViz.Presentation/Views/FactoryView.xaml.cs
@@ -8,6 +8,7 @@ using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Media3D;
+using BlockViz.Applications.Extensions;
 using BlockViz.Applications.Views;
 using BlockViz.Domain.Models;
 using HelixToolkit.Wpf;
@@ -189,7 +190,7 @@ namespace BlockViz.Presentation.Views
             if (viewport == null) return;
 
             var block = HitTestBlock(e.GetPosition(viewport));
-            UpdateTooltip(block?.Name);
+            UpdateTooltip(block);
         }
 
         private void OnViewportMouseLeave(object sender, MouseEventArgs e)
@@ -197,14 +198,16 @@ namespace BlockViz.Presentation.Views
             UpdateTooltip(null);
         }
 
-        private void UpdateTooltip(string? content)
+        private void UpdateTooltip(Block? block)
         {
-            if (string.IsNullOrWhiteSpace(content))
+            if (block == null)
             {
                 currentTooltipContent = null;
                 hoverToolTip.IsOpen = false;
                 return;
             }
+
+            var content = block.GetDisplayName();
 
             if (!string.Equals(currentTooltipContent, content, StringComparison.Ordinal))
             {

--- a/BlockViz.Presentation/Views/GanttView.xaml
+++ b/BlockViz.Presentation/Views/GanttView.xaml
@@ -86,6 +86,16 @@
                         <ToolTip Content="작업장 6의 블록만 확장하여 표시" />
                     </ToggleButton.ToolTip>
                 </ToggleButton>
+                <ToggleButton x:Name="expandAllButton"
+                              Content="모두 확장"
+                              Width="96"
+                              Margin="12,0,0,6"
+                              Checked="OnExpandAllChecked"
+                              Unchecked="OnExpandAllUnchecked">
+                    <ToggleButton.ToolTip>
+                        <ToolTip Content="모든 작업장의 겹친 블록을 행으로 분리" />
+                    </ToggleButton.ToolTip>
+                </ToggleButton>
             </WrapPanel>
         </StackPanel>
         <oxy:PlotView x:Name="plot" />


### PR DESCRIPTION
## Summary
- centralize Block.Name formatting through `GetDisplayName` and reuse it for color lookup and tooltips in the factory, schedule, and pie workflows
- introduce `BlockIntervalBarItem` and update the Gantt view model and contract to support expand-all layering while keeping block selections in sync
- refresh presentation views to surface consistent hover tooltips and the new "모두 확장" control across factory, schedule, and gantt screens

## Testing
- `dotnet build BlockViz.sln` *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0afffe28c832183df45aa2d352fb6