### PR TITLE
Restore PropertyGrid display for selected blocks

### DIFF
--- a/BlockViz.Presentation/Views/TreeView.xaml
+++ b/BlockViz.Presentation/Views/TreeView.xaml
@@ -1,47 +1,11 @@
 <UserControl x:Class="BlockViz.Presentation.Views.TreeView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <Grid>
-        <TextBlock Text="선택된 블록이 없습니다."
-                   FontSize="14"
-                   Foreground="Gray"
-                   HorizontalAlignment="Center"
-                   VerticalAlignment="Center">
-            <TextBlock.Style>
-                <Style TargetType="TextBlock">
-                    <Setter Property="Visibility" Value="Collapsed" />
-                    <Style.Triggers>
-                        <DataTrigger Binding="{Binding SelectedBlockProperties.Count}" Value="0">
-                            <Setter Property="Visibility" Value="Visible" />
-                        </DataTrigger>
-                    </Style.Triggers>
-                </Style>
-            </TextBlock.Style>
-        </TextBlock>
-
-        <TreeView ItemsSource="{Binding SelectedBlockProperties}"
-                  Margin="4"
-                  Background="Transparent">
-            <TreeView.Style>
-                <Style TargetType="TreeView">
-                    <Setter Property="Visibility" Value="Visible" />
-                    <Style.Triggers>
-                        <DataTrigger Binding="{Binding SelectedBlockProperties.Count}" Value="0">
-                            <Setter Property="Visibility" Value="Collapsed" />
-                        </DataTrigger>
-                    </Style.Triggers>
-                </Style>
-            </TreeView.Style>
-            <TreeView.Resources>
-                <Style TargetType="TreeViewItem">
-                    <Setter Property="IsExpanded" Value="True" />
-                </Style>
-            </TreeView.Resources>
-            <TreeView.ItemTemplate>
-                <HierarchicalDataTemplate ItemsSource="{Binding Children}">
-                    <TextBlock Text="{Binding Display}" />
-                </HierarchicalDataTemplate>
-            </TreeView.ItemTemplate>
-        </TreeView>
-    </Grid>
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit">
+  <Grid>
+    <!-- 간단/안정: 선택만 되면 바로 표시 -->
+    <xctk:PropertyGrid Name="PropertyGrid"
+                       AutoGenerateProperties="True"
+                       SelectedObject="{Binding SelectedBlock}" />
+  </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary
- restore the TreeView panel to use the Xceed PropertyGrid bound to SelectedBlock so block properties always render after selection

## Testing
- Not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d11559be6483218da26f6e3fa745df