### PR TITLE
Add block tooltips and expand default Gantt view

### DIFF
--- a/BlockViz.Application/Extensions/BlockExtensions.cs
+++ b/BlockViz.Application/Extensions/BlockExtensions.cs
@@ -45,5 +45,25 @@ namespace BlockViz.Applications.Extensions
             var end = block.GetEffectiveEnd();
             return end == null || date <= end.Value;
         }
+
+        public static string GetDisplayName(this Block block)
+        {
+            if (block == null)
+            {
+                return string.Empty;
+            }
+
+            if (!string.IsNullOrWhiteSpace(block.Name))
+            {
+                return block.Name;
+            }
+
+            if (block.BlockID != 0)
+            {
+                return block.BlockID.ToString();
+            }
+
+            return "Unnamed Block";
+        }
     }
 }

--- a/BlockViz.Application/ViewModels/FactoryViewModel.cs
+++ b/BlockViz.Application/ViewModels/FactoryViewModel.cs
@@ -7,10 +7,12 @@ using System.Windows.Media.Media3D;
 using BlockViz.Applications.Services;
 using BlockViz.Applications.Views;
 using System.Waf.Applications;
+using System.Windows;
 using System.Windows.Media;
 using HelixToolkit.Wpf;
 using BlockViz.Applications.Models;
 using BlockViz.Domain.Models;
+using BlockViz.Applications.Extensions;
 
 namespace BlockViz.Applications.ViewModels
 {
@@ -94,6 +96,7 @@ namespace BlockViz.Applications.ViewModels
                 if (model is ModelVisual3D mv3d &&
                     BlockProperties.GetData(mv3d) is Block b)
                 {
+                    var displayName = b.GetDisplayName();
                     foreach (var child in mv3d.Children)
                     {
                         if (child is BoxVisual3D box)
@@ -102,6 +105,10 @@ namespace BlockViz.Applications.ViewModels
                             var material = MaterialHelper.CreateMaterial(brush);
                             box.Material = material;
                             box.BackMaterial = material;
+                            ToolTipService.SetToolTip(box, displayName);
+                            ToolTipService.SetInitialShowDelay(box, 0);
+                            ToolTipService.SetBetweenShowDelay(box, 0);
+                            ToolTipService.SetShowDuration(box, int.MaxValue);
                         }
                     }
                 }

--- a/BlockViz.Application/ViewModels/GanttViewModel.cs
+++ b/BlockViz.Application/ViewModels/GanttViewModel.cs
@@ -286,12 +286,15 @@ namespace BlockViz.Applications.ViewModels
 
                 foreach (var segment in rowSegments[categoryIndex])
                 {
+                    var displayName = segment.Block.GetDisplayName();
                     series.Items.Add(new IntervalBarItem
                     {
                         CategoryIndex = categoryIndex,
                         Start = DateTimeAxis.ToDouble(segment.Start),
                         End = DateTimeAxis.ToDouble(segment.End),
-                        Color = colorService.GetOxyColor(segment.Block.Name) // 색상 동기화
+                        Color = colorService.GetOxyColor(segment.Block.Name), // 색상 동기화
+                        Title = displayName,
+                        Tag = segment.Block
                     });
                 }
             }
@@ -319,7 +322,7 @@ namespace BlockViz.Applications.ViewModels
         }
 
         private bool ShouldExpandWorkplace(int workplaceId)
-            => selectedWorkplaceId.HasValue && selectedWorkplaceId.Value == workplaceId;
+            => !selectedWorkplaceId.HasValue || selectedWorkplaceId.Value == workplaceId;
 
         private void EnsureDefaultRows(ICollection<string> axisLabels, ICollection<List<BlockSegment>> rowSegments)
         {

--- a/BlockViz.Application/ViewModels/ScheduleViewModel.cs
+++ b/BlockViz.Application/ViewModels/ScheduleViewModel.cs
@@ -7,10 +7,12 @@ using System.Windows.Media.Media3D;
 using BlockViz.Applications.Services;
 using BlockViz.Applications.Views;
 using System.Waf.Applications;
+using System.Windows;
 using System.Windows.Media;
 using HelixToolkit.Wpf;
 using BlockViz.Applications.Models;
 using BlockViz.Domain.Models;
+using BlockViz.Applications.Extensions;
 
 namespace BlockViz.Applications.ViewModels
 {
@@ -94,6 +96,7 @@ namespace BlockViz.Applications.ViewModels
                 if (model is ModelVisual3D mv3d &&
                     BlockProperties.GetData(mv3d) is Block b)
                 {
+                    var displayName = b.GetDisplayName();
                     foreach (var child in mv3d.Children)
                     {
                         if (child is BoxVisual3D box)
@@ -102,6 +105,10 @@ namespace BlockViz.Applications.ViewModels
                             var material = MaterialHelper.CreateMaterial(brush);
                             box.Material = material;
                             box.BackMaterial = material;
+                            ToolTipService.SetToolTip(box, displayName);
+                            ToolTipService.SetInitialShowDelay(box, 0);
+                            ToolTipService.SetBetweenShowDelay(box, 0);
+                            ToolTipService.SetShowDuration(box, int.MaxValue);
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- add a shared Block.GetDisplayName() helper so every view can fall back to a stable identifier when Name is empty
- surface the helper in Factory and Schedule visuals to show immediate block name tooltips while reusing existing colors
- update the Gantt view to expand all workplaces in the default mode and display consistent block-name tooltips without disturbing current controls

## Testing
- not run (dotnet CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d3896f53188321b35ef999ba6b6d43