### PR TITLE
Add tooltips and block name overlay for views

### DIFF
--- a/BlockViz.Application/Models/BlockPieSlice.cs
+++ b/BlockViz.Application/Models/BlockPieSlice.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using OxyPlot.Series;
+
+namespace BlockViz.Applications.Models
+{
+    /// <summary>
+    /// PieSlice 확장형 — 파이 차트 조각에 연결된 블록 이름 목록을 포함.
+    /// Label은 항상 빈 문자열로 유지하여 기존 UI(라벨 숨김)를 보존.
+    /// </summary>
+    public sealed class BlockPieSlice : PieSlice
+    {
+        private static readonly IReadOnlyList<string> EmptyNames = Array.Empty<string>();
+
+        public BlockPieSlice(string colorKey, IEnumerable<string>? displayNames, double value)
+            : base(string.Empty, value)
+        {
+            ColorKey = colorKey ?? string.Empty;
+
+            if (displayNames == null)
+            {
+                BlockNames = EmptyNames;
+            }
+            else
+            {
+                var list = displayNames
+                    .Where(name => !string.IsNullOrWhiteSpace(name))
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+
+                BlockNames = list.Count == 0
+                    ? EmptyNames
+                    : new ReadOnlyCollection<string>(list);
+            }
+        }
+
+        /// <summary>
+        /// 색상 계산 시 사용한 키 (기존 block.Name 또는 대체 값).
+        /// </summary>
+        public string ColorKey { get; }
+
+        /// <summary>
+        /// 슬라이스에 속한 블록 이름 목록 (오름차순, 중복 제거).
+        /// </summary>
+        public IReadOnlyList<string> BlockNames { get; }
+
+        /// <summary>
+        /// 목록이 비어 있지 않다면 첫 번째 항목을 대표 이름으로 사용.
+        /// </summary>
+        public string RepresentativeName => BlockNames.Count > 0 ? BlockNames[0] : string.Empty;
+    }
+}

--- a/BlockViz.Presentation/Views/PiView.xaml
+++ b/BlockViz.Presentation/Views/PiView.xaml
@@ -1,30 +1,85 @@
-﻿<UserControl x:Class="BlockViz.Presentation.Views.PiView"
+<UserControl x:Class="BlockViz.Presentation.Views.PiView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:oxy="http://oxyplot.org/wpf">
-    <DockPanel Margin="12">
-        <TextBlock DockPanel.Dock="Top" Text="작업장 가동률"
-                   FontSize="14" FontWeight="SemiBold" Margin="0,0,0,6" />
-        <ScrollViewer VerticalScrollBarVisibility="Auto">
-            <ItemsControl x:Name="cards">
-                <ItemsControl.ItemsPanel>
-                    <ItemsPanelTemplate>
-                        <WrapPanel />
-                    </ItemsPanelTemplate>
-                </ItemsControl.ItemsPanel>
-                <ItemsControl.ItemTemplate>
-                    <DataTemplate>
-                        <Border Background="White" Padding="10" Margin="6" CornerRadius="10">
-                            <StackPanel Width="260">
-                                <TextBlock Text="{Binding Title}" Margin="0,0,0,6" />
-                                <oxy:PlotView Model="{Binding}" Height="200" />
-                                <TextBlock Foreground="#64748B" FontSize="11"
-                                           Text="* 리본의 ‘레이블/퍼센트 표시’로 토글" />
-                            </StackPanel>
-                        </Border>
-                    </DataTemplate>
-                </ItemsControl.ItemTemplate>
-            </ItemsControl>
-        </ScrollViewer>
-    </DockPanel>
+    <Grid>
+        <DockPanel Margin="12">
+            <TextBlock DockPanel.Dock="Top" Text="작업장 가동률"
+                       FontSize="14" FontWeight="SemiBold" Margin="0,0,0,6" />
+            <ScrollViewer VerticalScrollBarVisibility="Auto">
+                <ItemsControl x:Name="cards">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <WrapPanel />
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Border Background="White" Padding="10" Margin="6" CornerRadius="10">
+                                <StackPanel Width="260">
+                                    <TextBlock Text="{Binding Title}" Margin="0,0,0,6" />
+                                    <oxy:PlotView Model="{Binding}" Height="200" MouseDown="OnPieMouseDown" />
+                                    <TextBlock Foreground="#64748B" FontSize="11"
+                                               Text="* 리본의 ‘레이블/퍼센트 표시’로 토글" />
+                                </StackPanel>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </ScrollViewer>
+        </DockPanel>
+
+        <Border x:Name="nameOverlay"
+                Background="#80000000"
+                Visibility="Collapsed"
+                PreviewMouseDown="OnOverlayBackgroundMouseDown">
+            <Grid HorizontalAlignment="Center"
+                  VerticalAlignment="Center"
+                  Margin="24">
+                <Border x:Name="nameOverlayPanel"
+                        Background="White"
+                        CornerRadius="12"
+                        Padding="18"
+                        MaxWidth="420"
+                        MaxHeight="420"
+                        BorderBrush="#FF94A3B8"
+                        BorderThickness="1.2">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <TextBlock x:Name="nameOverlayTitle"
+                                   FontSize="16"
+                                   FontWeight="SemiBold"
+                                   Foreground="#1F2937"
+                                   Text="블록 이름"
+                                   Margin="0,0,0,12" />
+                        <TextBox x:Name="nameOverlayText"
+                                 Grid.Row="1"
+                                 AcceptsReturn="True"
+                                 TextWrapping="NoWrap"
+                                 IsReadOnly="True"
+                                 VerticalScrollBarVisibility="Auto"
+                                 HorizontalScrollBarVisibility="Auto"
+                                 BorderThickness="1"
+                                 BorderBrush="#CBD5F5"
+                                 FontFamily="Cascadia Code, Consolas, 'Courier New', monospace"
+                                 FontSize="12"
+                                 MinWidth="260"
+                                 MinHeight="160"
+                                 Text=""
+                                 Padding="6" />
+                        <TextBlock x:Name="nameOverlayHint"
+                                   Grid.Row="2"
+                                   Margin="0,12,0,0"
+                                   Foreground="#64748B"
+                                   FontSize="11"
+                                   Text="ESC 또는 배경을 클릭하면 닫힙니다." />
+                    </Grid>
+                </Border>
+            </Grid>
+        </Border>
+    </Grid>
 </UserControl>

--- a/BlockViz.Presentation/Views/PiView.xaml.cs
+++ b/BlockViz.Presentation/Views/PiView.xaml.cs
@@ -1,7 +1,17 @@
-﻿using System.Collections.ObjectModel;
+using System;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.ComponentModel.Composition;
+using System.Linq;
+using System.Text;
+using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using BlockViz.Applications.Models;
 using BlockViz.Applications.Views;
+using OxyPlot;
+using OxyPlot.Series;
 using PlotModel = OxyPlot.PlotModel;
 
 namespace BlockViz.Presentation.Views
@@ -11,11 +21,23 @@ namespace BlockViz.Presentation.Views
     public partial class PiView : UserControl, IPiView
     {
         private ObservableCollection<PlotModel> models = new ObservableCollection<PlotModel>();
+        private PieSlice? activeSlice;
+        private PlotModel? activeModel;
+        private Brush? defaultOverlayBrush;
+        private Thickness defaultOverlayThickness;
 
         public PiView()
         {
             InitializeComponent();
+            Focusable = true;
+
+            models.CollectionChanged += OnPieModelsChanged;
             if (cards != null) cards.ItemsSource = models;
+
+            defaultOverlayBrush = nameOverlayPanel?.BorderBrush;
+            defaultOverlayThickness = nameOverlayPanel?.BorderThickness ?? new Thickness(1.2);
+
+            PreviewKeyDown += OnPreviewKeyDown;
         }
 
         public ObservableCollection<PlotModel> PieModels
@@ -23,9 +45,173 @@ namespace BlockViz.Presentation.Views
             get => models;
             set
             {
+                if (ReferenceEquals(models, value)) return;
+
+                if (models != null)
+                    models.CollectionChanged -= OnPieModelsChanged;
+
                 models = value ?? new ObservableCollection<PlotModel>();
+                models.CollectionChanged += OnPieModelsChanged;
+
                 if (cards != null) cards.ItemsSource = models;
+                HideOverlay();
             }
+        }
+
+        private void OnPieModelsChanged(object? sender, NotifyCollectionChangedEventArgs e)
+            => HideOverlay();
+
+        private void OnPreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape && IsOverlayVisible())
+            {
+                HideOverlay();
+                e.Handled = true;
+            }
+        }
+
+        private void OnPieMouseDown(object sender, MouseButtonEventArgs e)
+        {
+            if (sender is not OxyPlot.Wpf.PlotView plotView || plotView.ActualModel is not PlotModel model)
+            {
+                HideOverlay();
+                return;
+            }
+
+            var pos = e.GetPosition(plotView);
+            var screenPoint = new ScreenPoint(pos.X, pos.Y);
+
+            foreach (var series in model.Series.OfType<PieSeries>())
+            {
+                var result = series.GetNearestPoint(screenPoint, true);
+                if (result?.Item is PieSlice slice)
+                {
+                    if (ReferenceEquals(activeSlice, slice) && IsOverlayVisible())
+                    {
+                        HideOverlay();
+                    }
+                    else
+                    {
+                        ShowOverlay(model, slice);
+                    }
+                    e.Handled = true;
+                    return;
+                }
+            }
+
+            if (IsOverlayVisible())
+            {
+                HideOverlay();
+            }
+        }
+
+        private void OnOverlayBackgroundMouseDown(object sender, MouseButtonEventArgs e)
+        {
+            if (!IsOverlayVisible()) return;
+
+            if (nameOverlayPanel != null && e.OriginalSource is DependencyObject d && IsDescendantOf(d, nameOverlayPanel))
+            {
+                return;
+            }
+
+            HideOverlay();
+            e.Handled = true;
+        }
+
+        private void ShowOverlay(PlotModel model, PieSlice slice)
+        {
+            activeModel = model;
+            activeSlice = slice;
+
+            string chartTitle = string.IsNullOrWhiteSpace(model?.Title) ? "파이 차트" : model.Title;
+
+            if (slice is BlockPieSlice blockSlice)
+            {
+                var names = blockSlice.BlockNames ?? Array.Empty<string>();
+
+                if (names.Count > 0)
+                {
+                    var builder = new StringBuilder();
+                    for (int i = 0; i < names.Count; i++)
+                    {
+                        builder.Append(i + 1).Append(". ").Append(names[i]).AppendLine();
+                    }
+                    nameOverlayText.Text = builder.ToString().TrimEnd();
+                    nameOverlayTitle.Text = $"{chartTitle} — 블록 {names.Count}개";
+                    nameOverlayHint.Text = "Ctrl+C로 복사, ESC 또는 배경 클릭으로 닫기";
+                }
+                else
+                {
+                    nameOverlayText.Text = "표시할 블록 이름이 없습니다.";
+                    nameOverlayTitle.Text = $"{chartTitle} — 블록 없음";
+                    nameOverlayHint.Text = "ESC 또는 배경을 클릭하면 닫힙니다.";
+                }
+
+                UpdateOverlayBorder(slice.Fill);
+            }
+            else
+            {
+                nameOverlayText.Text = "해당 구간에는 연결된 블록이 없습니다.";
+                nameOverlayTitle.Text = $"{chartTitle} — 미사용";
+                nameOverlayHint.Text = "ESC 또는 배경을 클릭하면 닫힙니다.";
+                ResetOverlayBorder();
+            }
+
+            if (nameOverlay != null)
+                nameOverlay.Visibility = Visibility.Visible;
+
+            nameOverlayText.Focus();
+            nameOverlayText.CaretIndex = 0;
+            nameOverlayText.ScrollToHome();
+        }
+
+        private void HideOverlay()
+        {
+            if (nameOverlay != null)
+                nameOverlay.Visibility = Visibility.Collapsed;
+
+            nameOverlayText.Text = string.Empty;
+            ResetOverlayBorder();
+            activeSlice = null;
+            activeModel = null;
+        }
+
+        private void UpdateOverlayBorder(OxyColor color)
+        {
+            if (nameOverlayPanel == null) return;
+
+            if (!color.IsUndefined)
+            {
+                var brush = new SolidColorBrush(Color.FromArgb(color.A, color.R, color.G, color.B));
+                brush.Freeze();
+                nameOverlayPanel.BorderBrush = brush;
+                nameOverlayPanel.BorderThickness = new Thickness(2);
+            }
+            else
+            {
+                ResetOverlayBorder();
+            }
+        }
+
+        private void ResetOverlayBorder()
+        {
+            if (nameOverlayPanel == null) return;
+            nameOverlayPanel.BorderBrush = defaultOverlayBrush;
+            nameOverlayPanel.BorderThickness = defaultOverlayThickness;
+        }
+
+        private bool IsOverlayVisible()
+            => nameOverlay != null && nameOverlay.Visibility == Visibility.Visible;
+
+        private static bool IsDescendantOf(DependencyObject source, DependencyObject ancestor)
+        {
+            var current = source;
+            while (current != null)
+            {
+                if (ReferenceEquals(current, ancestor)) return true;
+                current = VisualTreeHelper.GetParent(current);
+            }
+            return false;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a BlockPieSlice model so each pie slice carries the associated block names and color key
- update PiViewModel to accumulate block durations with display-name fallbacks and emit the new slice type
- enhance Factory/Schedule views with hover tooltips and PiView with a selectable overlay that lists block names

## Testing
- dotnet build BlockViz.sln *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d39463c824832195ef9fd3978da2c6